### PR TITLE
Added Kani to CI.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -104,7 +104,7 @@ jobs:
         with:
           submodules: recursive
       - name: Verify with Kani
-        uses: model-checking/kani-github-action@02764e122079011adaf31e7d0630a8841d277507
+        uses: model-checking/kani-github-action@v0.19
         with:
           args: |
             --tests -p prost-types --default-unwind 3 \

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -106,10 +106,16 @@ jobs:
       - name: Verify with Kani
         uses: model-checking/kani-github-action@v0.19
         with:
+          enable-propproof: true
           args: |
             --tests -p prost-types --default-unwind 3 \
             --harness "tests::check_timestamp_roundtrip_via_system_time"
-          enable-propproof: true
+        # --default-unwind N roughly corresponds to how much effort
+        # Kani will spend trying to prove correctness of the
+        # program. Higher the number, more programs can be proven
+        # correct. However, Kani will require more time and memory. If
+        # Kani fails with "Failed Checks: unwinding assertion," this
+        # number may need to be raised for Kani to succeed.
 
   no-std:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -106,7 +106,6 @@ jobs:
       - name: Verify with Kani
         uses: model-checking/kani-github-action@02764e122079011adaf31e7d0630a8841d277507
         with:
-          working-directory: prost
           args: |
             --tests -p prost-types --default-unwind 3 \
             --harness "tests::check_timestamp_roundtrip_via_system_time"

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -104,7 +104,7 @@ jobs:
         with:
           submodules: recursive
       - name: Verify with Kani
-        uses: model-checking/kani-github-action@02764e1
+        uses: model-checking/kani-github-action@02764e122079011adaf31e7d0630a8841d277507
         with:
           working-directory: prost
           args: |

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -96,6 +96,21 @@ jobs:
           command: test
           args: --no-default-features
 
+  kani:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Verify with Kani
+        uses: model-checking/kani-github-action@02764e1
+        with:
+          working-directory: prost
+          args: --tests -p prost-types --default-unwind 3 \
+          --harness "tests::check_timestamp_roundtrip_via_system_time"
+          enable-propproof: true
+
   no-std:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -107,8 +107,9 @@ jobs:
         uses: model-checking/kani-github-action@02764e1
         with:
           working-directory: prost
-          args: --tests -p prost-types --default-unwind 3 \
-          --harness "tests::check_timestamp_roundtrip_via_system_time"
+          args: |
+            --tests -p prost-types --default-unwind 3 \
+            --harness "tests::check_timestamp_roundtrip_via_system_time"
           enable-propproof: true
 
   no-std:


### PR DESCRIPTION
This PR adds Kani to the CI.

- This PR adds Kani verification to only the `tests::check_timestamp_roundtrip_via_system_time` proptest harness. We focused on this harness because it was involved in bug #682
- Remaining harnesses within `prost-types` are blocked by [Kani issue 274](https://github.com/model-checking/kani/issues/274). We are working to implement the required features to resolve 274 and we will submit a second PR to enable these harnesses once Kani implements the feature.
- Harnesses outside of `prost-types` will be difficult to support within GitHub Actions due to Kani's large memory consumption when running these harnesses.

Note to kani-side reviewers:
- The PR will be corrected to use a proper version of Kani GitHub Action rather than the hash once the new release is done . Until then, this only works with the hash.